### PR TITLE
Update to normalizr 3

### DIFF
--- a/config/jest/test-setup.js
+++ b/config/jest/test-setup.js
@@ -1,4 +1,3 @@
-import { arrayOf } from 'normalizr'
 import { List } from 'immutable'
 import EntitiesConfig, {
   recordsFromFieldDefinitions,
@@ -41,12 +40,12 @@ const fieldDefinitions = {
 const schemas = schemasFromFieldDefinitions(fieldDefinitions)
 
 schemas.contact.define({
-  buckets: arrayOf(schemas.bucket),
+  buckets: [schemas.bucket],
   user: schemas.user,
-  emailAddresses: arrayOf(schemas.emailAddress)
+  emailAddresses: [schemas.emailAddress]
 })
 schemas.bucket.define({
-  bucketPermissions: arrayOf(schemas.bucketPermission)
+  bucketPermissions: [schemas.bucketPermission]
 })
 
 const records = recordsFromFieldDefinitions(fieldDefinitions)

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -10,6 +10,5 @@ git diff-index -p --cached --diff-filter=ACMRTUXB -G"${FORBIDDEN}" HEAD | \
   GREP_COLOR='37;41' grep --color -E $FORBIDDEN && echo "\nError: Found some debug-looking code. Please remove it before committing (use \"git commit --no-verify...\" to skip).\n" && exit 1
 
 yarn test -o
-yarn flow:check
 
 exit 0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:debug": "node --inspect-brk node_modules/.bin/jest --runInBand",
     "flow:check": "./node_modules/.bin/flow check",
     "hook": "bash ./hooks/install",
-    "deploy": "yarn version && yarn build && cd ./lib && npm publish"
+    "deploy": "yarn version && yarn build && cd ./lib && yarn harvest && npm publish",
+    "harvest": "echo It\\'s\\ harvest\\ time\\!"
   },
   "devDependencies": {
     "@types/lodash.flow": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "denormalizr": "^0.4.1",
     "immutable": "^3.8.1",
     "lodash": "^4.17.2",
-    "normalizr": "^2.3.0",
+    "normalizr": "^3.2.4",
     "prop-types": "^15.6.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "babel-polyfill": "^6.26.0",
-    "denormalizr": "^0.4.1",
     "immutable": "^3.8.1",
     "lodash": "^4.17.2",
     "normalizr": "^3.2.4",

--- a/src/module/sagas/apiRequest.js
+++ b/src/module/sagas/apiRequest.js
@@ -1,6 +1,6 @@
 import * as _ from 'lodash'
 import { call, put } from 'redux-saga/effects'
-import { arrayOf, normalize } from 'normalizr'
+import * as normalizr from 'normalizr'
 
 import { mergeKey } from '../utils'
 
@@ -35,12 +35,12 @@ const normalizeResponse = (givenResponse, schemaType) => {
   if (!_.isArrayLike(data) && _.startsWith(data.id, 'job_')) return { response }
 
   const schema = _.isArrayLike(data)
-    ? arrayOf(EntitiesConfig.schemas[schemaType])
+    ? new normalizr.schema.Array(EntitiesConfig.schemas[schemaType])
     : EntitiesConfig.schemas[schemaType]
 
   const cleanData = mergeKey(data, 'extraData')
 
-  const { entities, result } = normalize(
+  const { entities, result } = normalizr.normalize(
     cleanData,
     schema
   )

--- a/src/module/sagas/apiRequest.js
+++ b/src/module/sagas/apiRequest.js
@@ -1,6 +1,6 @@
 import * as _ from 'lodash'
 import { call, put } from 'redux-saga/effects'
-import * as normalizr from 'normalizr'
+import { normalize } from 'normalizr'
 
 import { mergeKey } from '../utils'
 
@@ -40,7 +40,7 @@ const normalizeResponse = (givenResponse, schemaType) => {
 
   const cleanData = mergeKey(data, 'extraData')
 
-  const { entities, result } = normalizr.normalize(
+  const { entities, result } = normalize(
     cleanData,
     schema
   )

--- a/src/module/sagas/apiRequest.js
+++ b/src/module/sagas/apiRequest.js
@@ -35,7 +35,7 @@ const normalizeResponse = (givenResponse, schemaType) => {
   if (!_.isArrayLike(data) && _.startsWith(data.id, 'job_')) return { response }
 
   const schema = _.isArrayLike(data)
-    ? new normalizr.schema.Array(EntitiesConfig.schemas[schemaType])
+    ? [EntitiesConfig.schemas[schemaType]]
     : EntitiesConfig.schemas[schemaType]
 
   const cleanData = mergeKey(data, 'extraData')

--- a/src/module/selectors.js
+++ b/src/module/selectors.js
@@ -2,7 +2,7 @@
 import * as _ from 'lodash'
 import { fromJS, Map, Record, List } from 'immutable'
 import { createSelector } from 'reselect'
-import * as normalizr from 'normalizr'
+import { denormalize } from 'normalizr'
 
 import MODULE_NAME from './identity'
 import { initialContainerState } from './reducer'
@@ -128,7 +128,7 @@ const requests: ReduxSelector<RequestMap> = createSelector(
 const entityItems: ReduxSelector<List<Record<any>>> = createSelector(
   entities, typeFromProps, idsFromProps,
   (entities, type, ids) => EntitiesConfig.schemas[type]
-    ? normalizr.denormalize(ids, [EntitiesConfig.schemas[type]], entities)
+    ? denormalize(ids, [EntitiesConfig.schemas[type]], entities)
     : ids
 )
 
@@ -186,7 +186,7 @@ _.memoize((containerId: string) => createItemResultSelector(
   containerEntityMap(containerId), containerIds(containerId), containerType(containerId),
   (entities, ids, type) =>
     EntitiesConfig.schemas[type]
-      ? normalizr.denormalize(ids, [EntitiesConfig.schemas[type]], entities)
+      ? denormalize(ids, [EntitiesConfig.schemas[type]], entities)
       : ids
 ))
 

--- a/src/module/selectors.js
+++ b/src/module/selectors.js
@@ -2,8 +2,7 @@
 import * as _ from 'lodash'
 import { fromJS, Map, Record, List } from 'immutable'
 import { createSelector } from 'reselect'
-import { arrayOf } from 'normalizr'
-import { denormalize } from 'denormalizr'
+import * as normalizr from 'normalizr'
 
 import MODULE_NAME from './identity'
 import { initialContainerState } from './reducer'
@@ -129,7 +128,7 @@ const requests: ReduxSelector<RequestMap> = createSelector(
 const entityItems: ReduxSelector<List<Record<any>>> = createSelector(
   entities, typeFromProps, idsFromProps,
   (entities, type, ids) => EntitiesConfig.schemas[type]
-    ? denormalize(ids, entities, arrayOf(EntitiesConfig.schemas[type]))
+    ? normalizr.denormalize(ids, new normalizr.schema.Array(EntitiesConfig.schemas[type]), entities)
     : ids
 )
 
@@ -185,9 +184,10 @@ _.memoize((containerId: string) => createShallowResultSelector(
 const containerItems: ContainerSelector<ReduxSelector<List<Record<any>>>> =
 _.memoize((containerId: string) => createItemResultSelector(
   containerEntityMap(containerId), containerIds(containerId), containerType(containerId),
-  (entities, ids, type) => EntitiesConfig.schemas[type]
-    ? denormalize(ids, entities, arrayOf(EntitiesConfig.schemas[type]))
-    : ids
+  (entities, ids, type) =>
+    EntitiesConfig.schemas[type]
+      ? normalizr.denormalize(ids, new normalizr.schema.Array(EntitiesConfig.schemas[type]), entities)
+      : ids
 ))
 
 /**

--- a/src/module/selectors.js
+++ b/src/module/selectors.js
@@ -128,7 +128,7 @@ const requests: ReduxSelector<RequestMap> = createSelector(
 const entityItems: ReduxSelector<List<Record<any>>> = createSelector(
   entities, typeFromProps, idsFromProps,
   (entities, type, ids) => EntitiesConfig.schemas[type]
-    ? normalizr.denormalize(ids, new normalizr.schema.Array(EntitiesConfig.schemas[type]), entities)
+    ? normalizr.denormalize(ids, [EntitiesConfig.schemas[type]], entities)
     : ids
 )
 
@@ -186,7 +186,7 @@ _.memoize((containerId: string) => createItemResultSelector(
   containerEntityMap(containerId), containerIds(containerId), containerType(containerId),
   (entities, ids, type) =>
     EntitiesConfig.schemas[type]
-      ? normalizr.denormalize(ids, new normalizr.schema.Array(EntitiesConfig.schemas[type]), entities)
+      ? normalizr.denormalize(ids, [EntitiesConfig.schemas[type]], entities)
       : ids
 ))
 

--- a/src/records.js
+++ b/src/records.js
@@ -1,9 +1,7 @@
 /* @flow */
 import * as _ from 'lodash'
 import { Record, fromJS, Map } from 'immutable'
-
-import IterableSchema from 'normalizr/lib/IterableSchema'
-import EntitySchema from 'normalizr/lib/EntitySchema'
+import * as normalizr from 'normalizr'
 
 import type {NormalizedEntityMap} from './module/selectors'
 
@@ -97,8 +95,8 @@ const entitiesToRecords = (normalizedEntityMap: NormalizedEntityMap): Normalized
  * @param {string[]=} keys
  * @returns {string[]}
  */
-const dependentEntityKeys = (schema: EntitySchema, keys: string[] = []): string[] => {
-  const schemaKey = schema.getKey()
+const dependentEntityKeys = (schema: normalizr.schema.Entity, keys: string[] = []): string[] => {
+  const schemaKey = schema.key
 
   if (keys.includes(schemaKey)) {
     return keys
@@ -106,11 +104,11 @@ const dependentEntityKeys = (schema: EntitySchema, keys: string[] = []): string[
 
   keys.push(schemaKey)
 
-  _.each(schema, (value, key) => {
-    if (value instanceof EntitySchema) {
+  _.each(schema.schema, (value, key) => {
+    if (value instanceof normalizr.schema.Entity) {
       dependentEntityKeys(value, keys)
-    } else if (value instanceof IterableSchema) {
-      dependentEntityKeys(value.getItemSchema(), keys)
+    } else if ((value instanceof normalizr.schema.Array) || (value instanceof normalizr.schema.Values)) {
+      dependentEntityKeys(value.schema, keys)
     }
   })
 

--- a/src/records.js
+++ b/src/records.js
@@ -107,8 +107,8 @@ const dependentEntityKeys = (schema: normalizr.schema.Entity, keys: string[] = [
   _.each(schema.schema, (value, key) => {
     if (value instanceof normalizr.schema.Entity) {
       dependentEntityKeys(value, keys)
-    } else if ((value instanceof normalizr.schema.Array) || (value instanceof normalizr.schema.Values)) {
-      dependentEntityKeys(value.schema, keys)
+    } else if ((value[0] instanceof normalizr.schema.Entity)) {
+      dependentEntityKeys(value[0], keys)
     }
   })
 

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -1,4 +1,4 @@
-import {Schema} from 'normalizr'
+import * as normalizr from 'normalizr'
 
 type Schemas = {
   [entityName: string]: Schema

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -10,17 +10,13 @@ type FieldDefinitions = {
   }
 }
 
-type SchemaDefinitions = {
-  [entityName: string]: {}
-}
-
 /**
  * Creates a Schema for each of the given record types.
  */
 function schemasFromFieldDefinitions (fieldDefinitions: FieldDefinitions): Schemas {
   const allSchemaTypes = Object.keys(fieldDefinitions)
   return allSchemaTypes.reduce((memo: Schemas, schemaType: string) => {
-    memo[schemaType] = new Schema(schemaType)
+    memo[schemaType] = new normalizr.schema.Entity(schemaType)
     return memo
   }, {})
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,13 +1469,6 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-denormalizr@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/denormalizr/-/denormalizr-0.4.1.tgz#b08ff8ca6d4b13b993f44d695117e8d721830505"
-  dependencies:
-    lodash "^4.16.3"
-    normalizr "^2.0.0"
-
 des.js@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.0.tgz#c074d2e2aa6a8a9a07dbd61f9a15c2cd83ec8ecc"
@@ -2862,7 +2855,7 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
-lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.3, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1:
+lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3117,12 +3110,6 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
     remove-trailing-separator "^1.0.1"
-
-normalizr@^2.0.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-2.3.1.tgz#ac12d771ce1fe6a43094c3d828caada4ed9a4540"
-  dependencies:
-    lodash "^4.17.2"
 
 normalizr@^3.2.4:
   version "3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,11 +3118,15 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalizr@^2.0.0, normalizr@^2.3.0:
+normalizr@^2.0.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-2.3.1.tgz#ac12d771ce1fe6a43094c3d828caada4ed9a4540"
   dependencies:
     lodash "^4.17.2"
+
+normalizr@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/normalizr/-/normalizr-3.2.4.tgz#16aafc540ca99dc1060ceaa1933556322eac4429"
 
 npm-run-path@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
Breaking changes:
- requires normalizr ^3.2.4
   - `arrayOf(schema)` has been deprecated. Use `[schema]` instead.
   - see normalizr docs for any additional functionality: https://github.com/paularmstrong/normalizr