### PR TITLE
FE-2890: Ensure nested object keys maintain original order

### DIFF
--- a/src/module/__snapshots__/reducer.spec.js.snap
+++ b/src/module/__snapshots__/reducer.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reducer handleMergeEntities preserves order of nested maps 1`] = `
+Array [
+  "a_key",
+  "z_key",
+  "h_key",
+  "b_key",
+  "c_key",
+  "d_key",
+  "e_key",
+  "aa_key",
+]
+`;

--- a/src/module/reducer.js
+++ b/src/module/reducer.js
@@ -3,7 +3,7 @@ import { fromJS, is, Set } from 'immutable'
 import { entitiesToRecords } from '../records'
 
 import actions from './actions'
-import { createReducer, safeMergeDeep } from './utils'
+import { createReducer, safeMergeDeep, fromJSOrdered } from './utils'
 
 // Initial module state
 const initialState = fromJS({
@@ -48,7 +48,7 @@ const handleResetContainerData = (state, { containerId }) =>
   state.setIn(['containers', containerId], initialContainerState)
 
 const handleMergeEntities = (state, { entities }) =>
-  state.updateIn(['entities'], (val) => entitiesToRecords(val.mergeWith(safeMergeDeep, entities)))
+  state.updateIn(['entities'], (val) => entitiesToRecords(val.mergeWith(safeMergeDeep, fromJSOrdered(entities))))
 
 const handleSetRequestStarted = (state, { requestId, ...rest }) =>
   state.mergeIn(['requests', requestId], { ...rest, requestedAt: new Date().getTime() })
@@ -58,7 +58,17 @@ const handleSetRequestCompleted = (state, { requestId, ...rest }) =>
 
 export {
   initialState,
-  initialContainerState
+  initialContainerState,
+
+  handleAddActiveRequest,
+  handleDeleteActiveRequest,
+  handleMergeContainerData,
+  handleMergeFilters,
+  handleSetFilters,
+  handleResetContainerData,
+  handleMergeEntities,
+  handleSetRequestStarted,
+  handleSetRequestCompleted
 }
 
 export default createReducer(initialState, {

--- a/src/module/reducer.spec.js
+++ b/src/module/reducer.spec.js
@@ -1,0 +1,182 @@
+import { schema } from 'normalizr'
+import { Record, OrderedMap, Map, fromJS } from 'immutable'
+import EntitiesConfig from '../Config'
+import {recordsFromFieldDefinitions} from '../records'
+import {schemasFromFieldDefinitions} from '../schemas'
+import {
+  handleAddActiveRequest,
+  handleDeleteActiveRequest,
+  handleMergeContainerData,
+  handleMergeFilters,
+  handleSetFilters,
+  handleResetContainerData,
+  handleMergeEntities,
+  handleSetRequestStarted,
+  handleSetRequestCompleted
+} from './reducer'
+
+describe('reducer', () => {
+  describe('handleMergeEntities', () => {
+    test('preserves order of nested maps', () => {
+      const fieldDefinitions = {
+        importedCsv: {
+          importOptions: {
+            columnMap: OrderedMap()
+          }
+        }
+      }
+
+      const records = recordsFromFieldDefinitions(fieldDefinitions)
+      const schemas = schemasFromFieldDefinitions(fieldDefinitions)
+
+      EntitiesConfig.configure({
+        records,
+        schemas
+      })
+
+      const state = Map({
+        entities: Map({
+          contact: Map({})
+        })
+      })
+      const entities = {
+        importedCsv: {
+          imported_csv_123: {
+            importOptions: {
+              columnMap: {
+                'fName': {
+                  'skip': false,
+                  'mappedHeader': 'custom_field',
+                  'exampleData': [
+                    'Olive',
+                    'austin',
+                    'who'
+                  ]
+                },
+                'lName': {
+                  'skip': false,
+                  'mappedHeader': 'custom_field',
+                  'exampleData': [
+                    'What',
+                    'When'
+                  ]
+                },
+                'eMail': {
+                  'skip': false,
+                  'mappedHeader': 'custom_field',
+                  'exampleData': [
+                    'olivecarroll@gmail.com',
+                    'bad email dawg'
+                  ]
+                },
+                'email2': {
+                  'skip': false,
+                  'mappedHeader': 'email',
+                  'exampleData': [
+                    'olivecarroll@yahoo.com'
+                  ]
+                },
+                'phoneNumber': {
+                  'skip': false,
+                  'mappedHeader': 'phone',
+                  'exampleData': [
+                    '(123) 456-7890',
+                    '123 333 4444'
+                  ]
+                },
+                'title': {
+                  'skip': false,
+                  'mappedHeader': 'title',
+                  'exampleData': [
+                    'CEO',
+                    'idk'
+                  ]
+                },
+                'company': {
+                  'skip': false,
+                  'mappedHeader': 'company',
+                  'exampleData': [
+                    'Canines Inc'
+                  ]
+                },
+                'website': {
+                  'skip': false,
+                  'mappedHeader': 'website',
+                  'exampleData': [
+                    'www.olive.com'
+                  ]
+                },
+                'homeStreet': {
+                  'skip': false,
+                  'mappedHeader': 'address_line_1',
+                  'type': 'Home',
+                  'exampleData': [
+                    '123 Main Street'
+                  ]
+                },
+                'homeCity': {
+                  'skip': false,
+                  'mappedHeader': 'address_city',
+                  'type': 'Home',
+                  'exampleData': [
+                    'Arlington'
+                  ]
+                },
+                'homeState': {
+                  'skip': false,
+                  'mappedHeader': 'address_state',
+                  'type': 'Home',
+                  'exampleData': [
+                    'VA'
+                  ]
+                },
+                'homeZip': {
+                  'skip': false,
+                  'mappedHeader': 'address_zip',
+                  'type': 'Home',
+                  'exampleData': [
+                    '20001'
+                  ]
+                },
+                'bucket': {
+                  'skip': false,
+                  'mappedHeader': 'buckets',
+                  'exampleData': [
+                    'Past Client'
+                  ]
+                },
+                'tag': {
+                  'skip': false,
+                  'mappedHeader': 'tags',
+                  'exampleData': [
+                    'Labrador'
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+      const result = handleMergeEntities(state, { entities })
+      const keys = result
+        .getIn(['entities', 'importedCsv', 'imported_csv_123', 'importOptions', 'columnMap']).keySeq().toArray()
+
+      expect(keys).toMatchObject([
+        'fName',
+        'lName',
+        'eMail',
+        'email2',
+        'phoneNumber',
+        'title',
+        'company',
+        'website',
+        'homeStreet',
+        'homeCity',
+        'homeState',
+        'homeZip',
+        'bucket',
+        'tag'
+      ])
+    })
+  })
+})

--- a/src/module/reducer.spec.js
+++ b/src/module/reducer.spec.js
@@ -14,6 +14,7 @@ import {
   handleSetRequestStarted,
   handleSetRequestCompleted
 } from './reducer'
+import {fromJSOrdered} from "./utils";
 
 describe('reducer', () => {
   describe('handleMergeEntities', () => {
@@ -43,115 +44,16 @@ describe('reducer', () => {
         importedCsv: {
           imported_csv_123: {
             importOptions: {
+              /* in immutable maps with more than 8 keys, the keys will lose order, unless fromJSOrdered is used */
               columnMap: {
-                'fName': {
-                  'skip': false,
-                  'mappedHeader': 'custom_field',
-                  'exampleData': [
-                    'Olive',
-                    'austin',
-                    'who'
-                  ]
-                },
-                'lName': {
-                  'skip': false,
-                  'mappedHeader': 'custom_field',
-                  'exampleData': [
-                    'What',
-                    'When'
-                  ]
-                },
-                'eMail': {
-                  'skip': false,
-                  'mappedHeader': 'custom_field',
-                  'exampleData': [
-                    'olivecarroll@gmail.com',
-                    'bad email dawg'
-                  ]
-                },
-                'email2': {
-                  'skip': false,
-                  'mappedHeader': 'email',
-                  'exampleData': [
-                    'olivecarroll@yahoo.com'
-                  ]
-                },
-                'phoneNumber': {
-                  'skip': false,
-                  'mappedHeader': 'phone',
-                  'exampleData': [
-                    '(123) 456-7890',
-                    '123 333 4444'
-                  ]
-                },
-                'title': {
-                  'skip': false,
-                  'mappedHeader': 'title',
-                  'exampleData': [
-                    'CEO',
-                    'idk'
-                  ]
-                },
-                'company': {
-                  'skip': false,
-                  'mappedHeader': 'company',
-                  'exampleData': [
-                    'Canines Inc'
-                  ]
-                },
-                'website': {
-                  'skip': false,
-                  'mappedHeader': 'website',
-                  'exampleData': [
-                    'www.olive.com'
-                  ]
-                },
-                'homeStreet': {
-                  'skip': false,
-                  'mappedHeader': 'address_line_1',
-                  'type': 'Home',
-                  'exampleData': [
-                    '123 Main Street'
-                  ]
-                },
-                'homeCity': {
-                  'skip': false,
-                  'mappedHeader': 'address_city',
-                  'type': 'Home',
-                  'exampleData': [
-                    'Arlington'
-                  ]
-                },
-                'homeState': {
-                  'skip': false,
-                  'mappedHeader': 'address_state',
-                  'type': 'Home',
-                  'exampleData': [
-                    'VA'
-                  ]
-                },
-                'homeZip': {
-                  'skip': false,
-                  'mappedHeader': 'address_zip',
-                  'type': 'Home',
-                  'exampleData': [
-                    '20001'
-                  ]
-                },
-                'bucket': {
-                  'skip': false,
-                  'mappedHeader': 'buckets',
-                  'exampleData': [
-                    'Past Client'
-                  ]
-                },
-                'tag': {
-                  'skip': false,
-                  'mappedHeader': 'tags',
-                  'exampleData': [
-                    'Labrador'
-                  ]
-                }
+                'a_key': {},
+                'z_key': {},
+                'h_key': {},
+                'b_key': {},
+                'c_key': {},
+                'd_key': {},
+                'e_key': {},
+                'aa_key': {}
               }
             }
           }
@@ -161,22 +63,7 @@ describe('reducer', () => {
       const keys = result
         .getIn(['entities', 'importedCsv', 'imported_csv_123', 'importOptions', 'columnMap']).keySeq().toArray()
 
-      expect(keys).toMatchObject([
-        'fName',
-        'lName',
-        'eMail',
-        'email2',
-        'phoneNumber',
-        'title',
-        'company',
-        'website',
-        'homeStreet',
-        'homeCity',
-        'homeState',
-        'homeZip',
-        'bucket',
-        'tag'
-      ])
+      expect(keys).toMatchSnapshot()
     })
   })
 })

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash'
-import { fromJS, is, List, Map, OrderedMap } from 'immutable'
+import { fromJS, is, List, Map, OrderedMap, Seq } from 'immutable'
 import { cancel, take, fork } from 'redux-saga/effects'
 import { createSelectorCreator } from 'reselect'
 import fbShallowEqual from 'fbjs/lib/shallowEqual'
@@ -148,6 +148,19 @@ export const createReducer = (initialState, handlers) =>
       ? handlers[type](state, payload, error)
       : state
   )
+
+/**
+ * By default, fromJS will use unordered Maps to build nested objects
+ * This method uses OrderedMaps instead, to preserve key order.
+ * @param {object|array} js
+ * @returns {List|Map}
+ */
+export const fromJSOrdered = (js) => {
+  return typeof js !== 'object' || js === null ? js :
+    Array.isArray(js) ?
+      Seq(js).map(fromJSOrdered).toList() :
+      Seq(js).map(fromJSOrdered).toOrderedMap();
+}
 
 const isList = List.isList
 const isMap = Map.isMap


### PR DESCRIPTION
By default, immutable will `fromJS` any object passed to `mergeWith`. In the `handleMergeEntities` reducer, we were passing a plain JS object to the `mergeWith` call (which gets `fromJS`'d under-the-hood of immutable).

This PR adds a `fromJSOrdered`, which provides similar output to the native `fromJS`, using `OrderedMap` in place of `Map`.