### PR TITLE
Fixes deep merging introduced in v0.4.0

### DIFF
--- a/src/module/__snapshots__/reducer.spec.js.snap
+++ b/src/module/__snapshots__/reducer.spec.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`reducer handleMergeEntities handles multiple merges to the same entity 1`] = `
+Immutable.List [
+  "one",
+  "two",
+  "three",
+]
+`;
+
+exports[`reducer handleMergeEntities handles multiple merges to the same entity 2`] = `
+Immutable.List [
+  "one",
+  "two",
+  "three",
+]
+`;
+
 exports[`reducer handleMergeEntities preserves order of nested maps 1`] = `
 Array [
   "a_key",

--- a/src/module/reducer.spec.js
+++ b/src/module/reducer.spec.js
@@ -65,5 +65,51 @@ describe('reducer', () => {
 
       expect(keys).toMatchSnapshot()
     })
+
+    test('handles multiple merges to the same entity', () => {
+      const fieldDefinitions = {
+        user: {
+          email: null,
+          settings: Map()
+        }
+      }
+
+      const records = recordsFromFieldDefinitions(fieldDefinitions)
+      const schemas = schemasFromFieldDefinitions(fieldDefinitions)
+
+      EntitiesConfig.configure({
+        records,
+        schemas
+      })
+
+      const state = Map({
+        entities: Map({
+          contact: Map({})
+        })
+      })
+      const entities1 = {
+        contact: {
+          contact_1: {
+            settings: {
+              enabledFeatures: ['one', 'two', 'three']
+            }
+          }
+        }
+      }
+      const entities2 = {
+        contact: {
+          contact_1: {
+            settings: {
+              whatever: 'hi'
+            }
+          }
+        }
+      }
+
+      const result1 = handleMergeEntities(state, { entities: entities1 })
+      const result2 = handleMergeEntities(result1, { entities: entities2 })
+      expect(result1.getIn(['entities', 'contact', 'contact_1', 'settings', 'enabledFeatures'])).toMatchSnapshot()
+      expect(result2.getIn(['entities', 'contact', 'contact_1', 'settings', 'enabledFeatures'])).toMatchSnapshot()
+    })
   })
 })

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -1,5 +1,5 @@
 import * as _ from 'lodash'
-import { fromJS, is, List, Map, OrderedMap, Seq } from 'immutable'
+import { fromJS, is, List, Map, OrderedMap, Seq, Record } from 'immutable'
 import { cancel, take, fork } from 'redux-saga/effects'
 import { createSelectorCreator } from 'reselect'
 import fbShallowEqual from 'fbjs/lib/shallowEqual'
@@ -165,7 +165,7 @@ export const fromJSOrdered = (js) => {
 const isList = List.isList
 const isMap = Map.isMap
 const isObject = _.isObject
-const isRecord = (a) => a && isMap(a._map) // There's no built-in `isRecord` :|
+const isRecord = (a) => a instanceof Record // There's no built-in `isRecord` :|
 
 /**
  * Custom 'merger' function for use with Immutable `mergeWith` that manually

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -163,9 +163,8 @@ export const fromJSOrdered = (js) => {
 }
 
 const isList = List.isList
-const isMap = Map.isMap
 const isObject = _.isObject
-const isRecord = (a) => a instanceof Record // There's no built-in `isRecord` :|
+export const isRecord = (a) => a instanceof Record // There's no built-in `isRecord` :|
 
 /**
  * Custom 'merger' function for use with Immutable `mergeWith` that manually

--- a/src/module/utils.spec.js
+++ b/src/module/utils.spec.js
@@ -1,0 +1,16 @@
+import {Map, OrderedMap, Record, List} from 'immutable'
+import {isRecord} from './utils'
+
+describe('utils', () => {
+  describe('isRecord', () => {
+    test('works', () => {
+      expect(isRecord(Map())).not.toBeTruthy()
+      expect(isRecord(OrderedMap())).not.toBeTruthy()
+      expect(isRecord(List())).not.toBeTruthy()
+      const RecordFactory = Record({})
+      const RecordInstance = RecordFactory({})
+      expect(isRecord(RecordFactory)).not.toBeTruthy()
+      expect(isRecord(RecordInstance)).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
In `module/utils.js` `mergeEntities`, we used an isRecord check that looked like this: `const isRecord = (a) => Map.isMap(a._map)`. This worked at the time because all Records have a `_map` property.

`OrderedMap`s also have a `_map` key, and now that we are using `OrderedMap` instead of `Map`, isRecord evaluated to true when given an `OrderedMap`. This caused is to merge data incorrectly, performing a `.set` instead `.merge`.